### PR TITLE
Fix link to Getting Started documentation

### DIFF
--- a/docs/guides/reticulum/getting-started/configure.md
+++ b/docs/guides/reticulum/getting-started/configure.md
@@ -184,7 +184,7 @@ UDP interfaces handle automatic discovery and linking between Reticulum nodes on
 
 ## RNode (LoRa Radio) Interfaces
 
-RNode is the firmware that turns supported LoRa hardware into a Reticulum radio interface. Once your device is flashed (see [Getting Started](getting-started.md)), you add an interface block pointing to its serial port and set the radio parameters for your region and use case.
+RNode is the firmware that turns supported LoRa hardware into a Reticulum radio interface. Once your device is flashed (see [Getting Started](index.md)), you add an interface block pointing to its serial port and set the radio parameters for your region and use case.
 
 ### Basic RNode Interface
 


### PR DESCRIPTION
Updated link in RNode interface section to point to the correct 'index.md' file.